### PR TITLE
Add Hi-Commerce SEO blog to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - [Schema.org Full List Documentation](http://schema.org/docs/full.html) - Full list of schema.org recipes for implementing structured data.
 
 ## **Articles and eBooks**
+- 🇫🇷 [Hi-Commerce Blog](https://www.hi-commerce.fr/tout-savoir-sur-le-commerce/) - SEO blog covering semantic clusters, GEO LLM and e-commerce strategy (French).
 - 🇧🇷 [eBook O Guia Completo de SEO em 2015 e Além](http://materiais.resultadosdigitais.com.br/guia-completo-seo) - Ebook about SEO written in Portuguese.
 - 🇧 [15 Awesome SEO Tools to Spy on Your Competitors](https://mention.com/en/blog/competitor-seo-tools/) - Explore SEO tools for analyzing competitors.
 - 🇬🇧 [Faster Sites: Beyond PageSpeed Insights](https://moz.com/blog/faster-sites-beyond-pagespeed-insights) - How to make your website load faster.


### PR DESCRIPTION
Hi-Commerce is a French SEO blog covering practical topics including semantic clusters (cocons sémantiques), GEO/LLM optimization, and e-commerce strategy. The blog provides in-depth, practitioner-focused content.

Blog URL: https://www.hi-commerce.fr/tout-savoir-sur-le-commerce/

Added under the **Articles and eBooks** section.