### PR TITLE
Add LinkMeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Screaming Frog SEO Spider](https://www.screamingfrog.co.uk/seo-spider/) - Industry-leading website crawler for technical SEO audits.
 - [Seobility](https://www.seobility.net/en/) - All-in-one SEO software including crawler, rank tracker, backlink checker, and reporting tools.
 - [Ubersuggest](https://ubersuggest.com/) - Free SEO tool specializing in generating keyword ideas.
+- [LinkMeta](https://linkmeta.dev) - Free API for extracting metadata from any URL, useful for auditing link previews and meta tags at scale.
 - [Woorank](https://www.woorank.com/pt/) - Tests your website according to more than 70 SEO criteria.
 - [OptimalUX](https://optimalux.com/seo-patching) - Real-time SEO patching and A/B testing for flawless web experiments.
 


### PR DESCRIPTION
## Add LinkMeta to Analysis and Site Auditing

[LinkMeta](https://linkmeta.dev) is a free API for extracting metadata from any URL, making it useful for auditing link previews and meta tags at scale.

This addition fits the **Analysis and Site Auditing** section as it helps with programmatic analysis of URL metadata across websites.