### PR TITLE
Add IndexNow and AI crawler SEO utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ## **Analysis and Site Auditing**
 - [IndexNow Changed URL Payload Builder](https://indexnow-payload-builder.vercel.app/) - Browser-only utility for preparing IndexNow changed-URL payloads, curl commands, and URL-submission checklists.
+
+- [AI Crawler Robots.txt Builder](https://ai-crawler-robots-builder.vercel.app/) - Browser-only generator and checker for AI crawler robots.txt rules covering GPTBot, OAI-SearchBot, ClaudeBot, Google-Extended, and PerplexityBot.
 - [Raven Tools](https://raventools.com/) - SEO software focused on site audits and rank tracking.
 - [Screaming Frog SEO Spider](https://www.screamingfrog.co.uk/seo-spider/) - Industry-leading website crawler for technical SEO audits.
 - [Seobility](https://www.seobility.net/en/) - All-in-one SEO software including crawler, rank tracker, backlink checker, and reporting tools.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ---
 
 ## **Analysis and Site Auditing**
+- [IndexNow Changed URL Payload Builder](https://indexnow-payload-builder.vercel.app/) - Browser-only utility for preparing IndexNow changed-URL payloads, curl commands, and URL-submission checklists.
 - [Raven Tools](https://raventools.com/) - SEO software focused on site audits and rank tracking.
 - [Screaming Frog SEO Spider](https://www.screamingfrog.co.uk/seo-spider/) - Industry-leading website crawler for technical SEO audits.
 - [Seobility](https://www.seobility.net/en/) - All-in-one SEO software including crawler, rank tracker, backlink checker, and reporting tools.


### PR DESCRIPTION
Adds a single technical SEO utility entry for a free browser-only IndexNow payload builder.

The tool helps site owners prepare changed-URL JSON payloads, curl commands, and submission checklists for IndexNow without uploading URLs to a server.

I checked the current README and open issues/PRs for this exact title and URL before opening this.